### PR TITLE
Update slideio to version 2.7.1 to fix issues with reading slides

### DIFF
--- a/histogpt/helpers/patching.py
+++ b/histogpt/helpers/patching.py
@@ -1,4 +1,4 @@
-""" 
+"""
 Whole Slide Image Patch Feature Extractor
 Author: Valentin Koch / Helmholtz Munich
 """
@@ -65,7 +65,7 @@ class PatchingConfigs:
 class SlideDataset(Dataset):
     def __init__(
         self,
-        slide: slideio.py_slideio.Slide,
+        slide: slideio.Slide,
         coordinates: pd.DataFrame,
         patch_size: int = 512,
         transform: list = None
@@ -104,7 +104,7 @@ def get_models(args, device):
     model.head = nn.Identity()
     state_dict = torch.load(args.model_path)
     model.load_state_dict(state_dict['model'], strict=True)
-    
+
     model.to(device)
     model.eval()
 
@@ -346,7 +346,7 @@ def patches_to_feature(
 
 
 def extract_features(
-    slide: slideio.py_slideio.Slide,
+    slide: slideio.Slide,
     slide_name: str,
     model_dicts: List[Dict],
     device: torch.device,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "openai>=1.14.0",
         #"openslide-python>=1.3.1",
         "sacremoses>=0.1.1",
-        "slideio>=2.5.0",
+        "slideio>=2.7.1",
         "torch>=2.1.0",
         "transformers>=4.37.2",
         #"flamingo-pytorch>=0.1.2",


### PR DESCRIPTION
With version 2.5.0 of slideio (that was prior required due to imports using slideio.py_slideio), all pixels were read as the same value. With version 2.7.1 it works correctly and the import paths are now adjusted.